### PR TITLE
Remove extra modifiers that might break a custom schema.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export const getZodConstructor = (
 	if (field.isList) extraModifiers.push('array()')
 	if (field.documentation) {
 		zodType = computeCustomSchema(field.documentation) ?? zodType
-		extraModifiers.push(...computeModifiers(field.documentation))
+		extraModifiers = ['', ...computeModifiers(field.documentation)]
 	}
 	if (!field.isRequired && field.type !== 'Json') extraModifiers.push('nullish()')
 	// if (field.hasDefaultValue) extraModifiers.push('optional()')


### PR DESCRIPTION
```typescript
model Foo {
  bar Int? /// @zod.custom(z.union([z.literal(33),z.literal(44)]))`
}
```

would result in `z.union([z.literal(33), z.literal(43)]).int().nullish()`. This change resets the modifiers array and thereby removes `int()`, which doesn't exist on `z.union`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/daotl/zod-prisma/1)
<!-- Reviewable:end -->
